### PR TITLE
Do not delegate by default

### DIFF
--- a/peps/pep-0729.rst
+++ b/peps/pep-0729.rst
@@ -165,28 +165,31 @@ Relationship with the Steering Council
 
 Just like today, the Python Steering Council would remain responsible for the
 overall direction of the Python language and would continue to decide on
-typing-related PEPs. However, smaller changes to the type system could be made
-by the Typing Council directly, and the Steering Council may delegate the
-decision on some PEPs to the Typing Council.
+typing-related PEPs. The Typing Council would provide written opinions and
+recommendations to the Steering Council on typing-related PEPs.
+
+However, smaller changes to the type system could be made
+by the Typing Council directly. The Steering Council could also choose
+to delegate decisions on some PEPs to the Typing Council (exactly as any other
+PEP delegation).
 
 Some examples of how past and recent issues could have been handled under this model:
 
-- A PEP like :pep:`695` (type parameter syntax),
-  which changes the language syntax,
-  would be decided upon by the Steering Council, but they could consult the
-  Typing Council for opinions or endorsements. Similarly, PEPs like
-  :pep:`702` would be decided upon by the Steering
-  Council, because it expands the type system beyond pure typing. Other examples we
-  expect would be decided by the SC include
-  :pep:`718` and :pep:`727`.
-- A PEP like :pep:`698` (``@override``),
-  which affects only users of type checkers
-  and does not change the overall language, would likely be delegated by the SC
-  to the Typing Council for a decision, exactly as any other PEP delegation.
-  Other examples we expect would be delegated include
+- A PEP like :pep:`695` (type parameter syntax), which changes the language
+  syntax, would need to be decided upon by the Steering Council; the Typing
+  Council would merely provide opinion or endorsement. Similarly, PEPs
+  like :pep:`702` would be decided upon by the Steering
+  Council, because it concerns runtime behaviour beyond pure typing. Other examples
+  that would need to be decided by the SC include :pep:`718` and :pep:`727`.
+- A PEP like :pep:`698` (``@override``), which affects only users of type
+  checkers and does not change the overall language, would also by default
+  be decided upon by the Steering Council. However, such PEPs could be
+  delegated to the Typing Council for a decision (like any other PEP delegation).
+  Other examples of PEPs that could potentially be delegated include
   :pep:`647`, :pep:`655`, :pep:`673`, and :pep:`675`.
-- Adding a smaller feature, such as :data:`typing.Never` as an alias for :data:`typing.NoReturn`, would be
-  done by means of a PR to the spec and conformance test suite. The Typing
+- Adding a smaller feature, such as :data:`typing.Never` as an alias for
+  :data:`typing.NoReturn`, would be done by means of a PR to the spec and
+  conformance  test suite. The Typing
   Council would then decide whether or not to merge the PR. They may ask for the
   feature to be specified and discussed in a PEP if they feel that is warranted.
 - If there is confusion about the interpretation of some part of the spec, like


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--7.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->